### PR TITLE
Allow sandboxes to be used with token logins

### DIFF
--- a/salesforce_oauth_request/utils.py
+++ b/salesforce_oauth_request/utils.py
@@ -34,6 +34,7 @@ def login(username = None,
         r = token_login(username = username,
                         password = password,
                         token = token,
+                        sandbox = sandbox,
                         client_id = client_id,
                         client_secret = client_secret)
     else:


### PR DESCRIPTION
This appears to be an oversight. Just passing sandbox into the token
login method.